### PR TITLE
Update array to allow sizeless references for convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 test/bin/**
+.idea/**
+CMakeLists.txt

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ STL containers cannot be used without new/malloc.
 The goal is to provide an implementation which is portable to small micro
 controllers and doesn't take up too much RAM/ROM.
 
-# Usage
+## Usage
 
 You can include the entire namespace:
 
@@ -15,7 +15,43 @@ You can include the entire namespace:
 
 You can also include any of the individual headers.
 
-# Testing
+### Design
+
+The classes are designed to be consumed in a manner as similar as possible to
+the STL containers they replace. The only difference is the underlying capacity
+must be specified at instantiation. In practice, what this means is that typical
+use follows a pattern similar to this:
+
+    sstl::array<int, 100> a;
+
+    size_t ExampleSizeOfArray(sstl::array<int>& some_array) {
+    	return some_array.size();
+    }
+
+    sstl::array<int>& aref = a;
+
+As you can see, after the inital creation/allocation, the capacity is no longer
+a necessary template argument for references. This means each container type can
+be used in function signatures without requiring the size (unless desired) or
+the use of templated functions to accept arbitrary sizes. It is also unnecessary
+to pass the size as a distinct parameter along side the container, as this
+information is stored internally.
+
+### Compatibility
+
+While the classes operate as closely as possible to their STL counterparts,
+sometimes this is not possible due to the constraints of static allocation.
+
+Sometimes, the functionality will diverge to allow for developer conveniences.
+A good example is the `sstl::array` class shown above. A `std::array` does not
+provide a type-only template variation, requiring any function dealing with an
+array to accept a given size at compile time. The example above demonstrates how
+this isn't necessary, and can make passing arbitrary length array references
+into functions much less painful. A limitation of this approach is that the
+array must be passed with it's size template parameter if it is to be passed by
+value instead of as a reference.
+
+## Testing
 
 There is a small test setup in the `test` folder which can be run. From that
 folder run:
@@ -25,6 +61,6 @@ folder run:
 Any cpp files in `tests/src` will be built and run from `src\test.cpp`'s `int main()`
 function.
 
-# License
+## License
 
 MIT

--- a/inc/array.h
+++ b/inc/array.h
@@ -7,8 +7,14 @@
 namespace sstl {
 
 /** Basic fixed-size array class. */
-template<typename T, size_t N>
-class array {
+template<typename T, size_t N = 0>
+class array;
+
+/** Common zero-size base class for all fixed-size arrays. */
+template<typename T>
+class array<T> {
+	typedef array<T, 1> child;
+
   public:
 	typedef T                 value_type;
 	typedef value_type*       pointer;
@@ -22,58 +28,61 @@ class array {
 	typedef sstl::reverse_iterator<iterator>       reverse_iterator;
 	typedef sstl::reverse_iterator<const_iterator> const_reverse_iterator;
 
-	/** Default constructor. */
-	array() { fill_n(data_, N, T()); }
-	/** Copy constructor. */
-	array(const array& other) { copy_n(other.begin(), N, data_); }
-	/** Construct from a compatible array. */
-	template<typename T2, size_type N2>
-	array(const array<T2, N2>& other) {
-		fill(copy_n(other.begin(), min(N, N2), data_), end(), T());
-	}
-	/** Initialized constructor. */
-	explicit array(const_reference val) { fill_n(data_, N, val); }
-
 	/** Copy assignment operator. */
 	array& operator=(const array& rhs) {
-		copy_n(rhs.begin(), N, data_);
+		copy_n(rhs.begin(), size(), static_cast<child*>(this)->data_);
 		return *this;
 	}
 	/** Copy assignment operator for compatible array. */
-	template<typename T2, size_type N2>
+	template<typename T2, size_t N2>
 	array& operator=(const array<T2, N2>& rhs) {
-		copy_n(rhs.begin(), min(N, N2), data_);
+		fill(copy_n(rhs.begin(),
+		            min(rhs.size(), size()),
+		            static_cast<child*>(this)->data_), end(), T());
 		return *this;
 	}
+
 	/** Random access operator. */
-	reference operator[](size_type pos) { return data_[pos]; }
-	const_reference operator[](size_type pos) const { return data_[pos]; }
+	reference operator[](size_type pos) {
+		return static_cast<child*>(this)->data_[pos];
+	}
+	const_reference operator[](size_type pos) const {
+		return static_cast<const child*>(this)->data_[pos];
+	}
 
 	/** Access element at pos with bounds checking. */
-	reference at(size_type pos) { return data_[pos % N]; }
-	const_reference at(size_type pos) const { return data_[pos % N]; }
+	reference at(size_type pos) {
+		return static_cast<child*>(this)->data_[pos % capacity_];
+	}
+	const_reference at(size_type pos) const {
+		return static_cast<const child*>(this)->data_[pos % capacity_];
+	}
 
 	/** Access the first element. */
-	reference front() { return data_[0]; }
-	const_reference front() const { return data_[0]; }
+	reference front() { return static_cast<child*>(this)->data_[0]; }
+	const_reference front() const {
+		return static_cast<const child*>(this)->data_[0];
+	}
 
 	/** Access the last element. */
-	reference back() { return data_[N - 1]; }
-	const_reference back() const { return data_[N - 1]; }
+	reference back() { return static_cast<child*>(this)->data_[capacity_ - 1]; }
+	const_reference back() const {
+		return static_cast<const child*>(this)->data_[capacity_ - 1];
+	}
 
 	/** Access the underlying array pointer. */
-	pointer data() { return data_; }
-	const_pointer data() const { return data_; }
+	pointer data() { return static_cast<child*>(this)->data_; }
+	const_pointer data() const { return static_cast<const child*>(this)->data_; }
 
 	/** Returns an iterator to the first element in the array. */
-	iterator begin() { return data_; }
-	const_iterator begin() const { return data_; }
-	const_iterator cbegin() const { return data_; }
+	iterator begin() { return static_cast<child*>(this)->data_; }
+	const_iterator begin() const { return static_cast<const child*>(this)->data_; }
+	const_iterator cbegin() const { return static_cast<const child*>(this)->data_; }
 
 	/** Returns an iterator to the invalid element immediately following the array. */
-	iterator end() { return begin() + N; }
-	const_iterator end() const { return begin() + N; }
-	const_iterator cend() const { return begin() + N; }
+	iterator end() { return begin() + capacity_; }
+	const_iterator end() const { return begin() + capacity_; }
+	const_iterator cend() const { return begin() + capacity_; }
 
 	/** Returns a reverse iterator to the first element of the reversed container. */
 	reverse_iterator rbegin() { return reverse_iterator(end()); }
@@ -86,11 +95,62 @@ class array {
 	const_reverse_iterator crend() const { return rend(); }
 
 	/** Checks whether the container has no elements. */
-	bool empty() const { return N == 0; }
+	bool empty() const { return false; }
 	/** Returns the number of elements in the container. */
-	size_type size() const { return N; }
+	size_type size() const { return capacity_; }
 	/** Returns the maximum possible number of elements. */
-	size_type max_size() const { return N; }
+	size_type max_size() const { return capacity_; }
+
+  protected:
+	array(size_type cap) : capacity_(cap) {}
+	~array() {}
+
+  private:
+	size_type capacity_;
+};
+
+/** Child class with size-specific storage for the underlying array. */
+template<typename T, size_t N>
+class array : public array<T> {
+	friend class array<T>;
+	typedef array<T> base;
+
+  public:
+	typedef typename base::pointer                pointer;
+	typedef typename base::const_pointer          const_pointer;
+	typedef typename base::value_type             value_type;
+	typedef typename base::reference              reference;
+	typedef typename base::const_reference        const_reference;
+	typedef typename base::size_type              size_type;
+	typedef typename base::difference_type        difference_type;
+	typedef typename base::iterator               iterator;
+	typedef typename base::const_iterator         const_iterator;
+	typedef typename base::reverse_iterator       reverse_iterator;
+	typedef typename base::const_reverse_iterator const_reverse_iterator;
+
+	/** Default constructor. */
+	array() : base(N) { fill_n(data_, N, T()); }
+	/** Copy constructor. */
+	array(const array& other) : base(N) { copy_n(other.begin(), N, data_); }
+	/** Construct from a compatible array. */
+	template<typename T2, size_t N2>
+	array(const array<T2, N2>& other) : base(N) {
+		fill(copy_n(other.begin(), min(other.size(), N), data_), base::end(), T());
+	}
+	/** Initialized constructor. */
+	explicit array(const_reference val) : base(N) { fill_n(data_, N, val); }
+
+	/** Copy assignment operator. */
+	array& operator=(const array& rhs) {
+		copy_n(rhs.begin(), N, data_);
+		return *this;
+	}
+	/** Copy assignment operator for compatible array. */
+	template<typename T2, size_t N2>
+	array& operator=(const array<T2, N2>& rhs) {
+		fill(copy_n(rhs.begin(), min(rhs.size(), N), data_), base::end(), T());
+		return *this;
+	}
 
   private:
 	T data_[N];

--- a/test/src/array.cpp
+++ b/test/src/array.cpp
@@ -10,13 +10,10 @@ struct array_construct : public test {
 
 	bool run() {
 		sstl::array<char, 7> a;
-
 		sstl::array<char, 7> b(42);
-
 		sstl::array<char, 7> c(b);
-
-		sstl::array<char, 12> d(c);
-
+		sstl::array<char>& c1 = c;
+		sstl::array<char, 12> d(c1);
 		sstl::array<int, 5> e(d);
 
 		return
@@ -127,10 +124,6 @@ struct array_capacity : public test {
 		a[5] = 13;
 
 		if (a.empty() || a.size() != 10 || a.max_size() != 10) { return false; }
-
-		sstl::array<int, 0> b;
-
-		if (!b.empty() || b.size() || b.max_size()) { return false; }
 
 		return true;
 	}


### PR DESCRIPTION
Splits the array class into a base/child arrangement. The base class is a specialization of the template for 0 size. All functionality except the variable sized storage and constructors exist in the base. This allows a base reference to act like the complete type in every way, except during construction/instantiation where a size must be provided.

Technically, a 0 sized array is possible for the `std::array` it is modelled after, but the underlying array being 0 elements is not standards compliant and causes a warning under certain compiler configurations. Therefor, I feel it is safe to steal the 0 size template for the base specialization.

Because the variable sized storage is provided by the child class, a "hack" was necessary to allow the base class to access child class members safely, without the use of CRTP (as it does not result in a single base class, but many.) To do this, we define a child typedef on the base which is the size 1 instance of the template. We then cast our `this` pointer to the child type when access is needed. Normally this is dangerous behaviour, but within the implementation we have strict control over what children are allowed to do, and thus the data layout (as used) should remain consistent across all template children. In this respect the base class is simply an implementation detail, and not intended to be subclassed by users directly.