### PR TITLE
Create aligned storage class and helper traits

### DIFF
--- a/inc/type_traits.h
+++ b/inc/type_traits.h
@@ -1,0 +1,77 @@
+#ifndef STATIC_STL_TYPE_TRAITS_H_
+#define STATIC_STL_TYPE_TRAITS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace sstl {
+
+/** Wraps a static constant of specified type. */
+template<typename T, T v>
+struct integral_constant {
+	static const T value = v;
+
+	typedef T                 value_type;
+	typedef integral_constant type;
+
+	operator value_type() const { return value; }
+	value_type operator()() const { return value; }
+};
+
+/** If B is true, enable_if has a public member typedef type, equal to T. */
+template<bool B, class T = void>
+struct enable_if {};
+
+template<class T>
+struct enable_if<true, T> { typedef T type; };
+
+namespace detail {
+template<typename T>
+struct alignment_of {
+	struct alignment_wrapper {
+		char pad;
+		T type;
+	};
+	static const size_t value = sizeof(alignment_wrapper) - sizeof(T);
+};
+} /* namespace detail */
+
+/** Provides the member constant value equal to the alignment requirement of the type T. */
+template<typename T>
+struct alignment_of :
+	public integral_constant<size_t, detail::alignment_of<T>::value> {};
+
+/** Provides the nested type type, which is a trivial type with the same alignment as Align . */
+template<size_t Align>
+struct aligned_pod { typedef long double type; };
+
+template<>
+struct aligned_pod<1> { typedef uint8_t type; };
+
+template<>
+struct aligned_pod<2> { typedef uint16_t type; };
+
+template<>
+struct aligned_pod<4> { typedef uint32_t type; };
+
+template<>
+struct aligned_pod<8> { typedef uint64_t type; };
+
+/** Provides the nested type type, which is a trivial type of size N with alignment Align. */
+template<size_t N, size_t Align>
+struct aligned_storage {
+	union type {
+		unsigned char data_[N];
+		typename aligned_pod<Align>::type align_;
+	};
+
+  private:
+	/** This type gives compilation errors if we can't align on the requested boundary for this platform. */
+	typedef typename
+	enable_if < (Align <= alignment_of<aligned_pod<0>::type>::value) >::type
+	alignment_possible;
+};
+
+} /* namespace sstl */
+
+#endif /* STATIC_STL_TYPE_TRAITS_H_ */

--- a/inc/utility.h
+++ b/inc/utility.h
@@ -3,8 +3,6 @@
 
 namespace sstl {
 
-namespace rel_ops {
-
 /** Implements operator!= in terms of operator==. */
 template<class T>
 bool operator!=(const T& lhs, const T& rhs) { return !(lhs == rhs); }
@@ -20,8 +18,6 @@ bool operator<=(const T& lhs, const T& rhs) { return !(rhs < lhs); }
 /** Implements operator>= in terms of operator<. */
 template<class T>
 bool operator>=(const T& lhs, const T& rhs) { return !(lhs < rhs); }
-
-} /* namespace rel_ops */
 
 } /* namespace sstl */
 

--- a/test/src/array.cpp
+++ b/test/src/array.cpp
@@ -103,8 +103,6 @@ struct array_iterate : public test {
 			*it = i++;
 		}
 
-		using namespace sstl::rel_ops;
-
 		for (auto it = a.crbegin(); it != a.crend(); ++it) {
 			if (*it != --i) { return false; }
 		}

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -1,0 +1,55 @@
+#include "test.h"
+
+#include "type_traits.h"
+
+namespace type_traits {
+
+struct integral_const : public test {
+	integral_const() : test("integral_constant<> values") {}
+
+	bool run() {
+		if (sstl::integral_constant<bool, false>::value) { return false; }
+
+		if (sstl::integral_constant<int, 32>::value != 32) { return false; }
+
+		if (sstl::integral_constant<char, 64>::value != 64) { return false; }
+
+		return true;
+	}
+};
+
+integral_const t1;
+
+struct alignment : public test {
+	alignment() : test("alignment_of<> types") {}
+
+	bool run() {
+		if (sstl::alignment_of<uint8_t>::value != 1) { return false; }
+
+		if (sstl::alignment_of<uint16_t>::value != 2) { return false; }
+
+		if (sstl::alignment_of<uint32_t>::value != 4) { return false; }
+
+		if (sstl::alignment_of<uint64_t>::value != 8) { return false; }
+
+		return true;
+	}
+};
+
+alignment t2;
+
+struct aligned_storage_type : public test {
+	aligned_storage_type() : test("aligned_storage<> container") {}
+
+	bool run() {
+		if (sizeof(sstl::aligned_storage<5, 4>::type) != 8) { return false; }
+
+		if (sizeof(sstl::aligned_storage<15, 8>::type) != 16) { return false; }
+
+		return true;
+	}
+};
+
+aligned_storage_type t3;
+
+} /* namespace type_traits */


### PR DESCRIPTION
Implements a class which can specify size and alignment requirements as template arguments. This is intended to be used as underlying storage for future containers.