### PR TITLE
Detect core count and compile in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+NUM_CORES := $(shell grep -c ^processor /proc/cpuinfo)
+MAKEFLAGS += --jobs=$(NUM_CORES) --max-load=$(NUM_CORES)
+
 PROG := sstl
 
 SRC_DIR := test


### PR DESCRIPTION
Configure make to run jobs in parallel for faster builds. This will make a bigger difference when there's more files to build.