### PR TITLE
Convert vector to use raw memory instead of default constructed objects

### DIFF
--- a/inc/memory.h
+++ b/inc/memory.h
@@ -1,0 +1,120 @@
+#ifndef STATIC_STL_MEMORY_H_
+#define STATIC_STL_MEMORY_H_
+
+#include "iterator.h"
+
+namespace sstl {
+
+/** Copies elements from the range [first, last] to an uninitialized memory area beginning at d_first. */
+template<class InputIt, class ForwardIt>
+ForwardIt uninitialized_copy(InputIt first, InputIt last, ForwardIt d_first) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; first != last; ++first, ++d_first) {
+		new(static_cast<void*>(&*d_first)) value_type(*first);
+	}
+
+	return d_first;
+}
+
+/** Copies count elements from a range beginning at first to an uninitialized memory area beginning at d_first. */
+template<class InputIt, class Size, class ForwardIt>
+ForwardIt uninitialized_copy_n(InputIt first, Size count, ForwardIt d_first) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; count; ++first, ++d_first, --count) {
+		new(static_cast<void*>(&*d_first)) value_type(*first);
+	}
+
+	return d_first;
+}
+
+/** Copies the given value to an uninitialized memory area, defined by the range [first, last]. */
+template<class ForwardIt, typename T>
+void uninitialized_fill(ForwardIt first, ForwardIt last, const T& value) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; first != last; ++first) {
+		new(static_cast<void*>(&*first)) value_type(value);
+	}
+}
+
+/** Copies the given value value to the first count elements in an uninitialized memory area beginning at first. */
+template<class ForwardIt, class Size, typename T>
+ForwardIt uninitialized_fill_n(ForwardIt first, Size count, const T& value) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; count; ++first, --count) {
+		new(static_cast<void*>(&*first)) value_type(value);
+	}
+
+	return first;
+}
+
+/** Constructs objects in the uninitialized storage designated by the range [first, last] by default-initialization. */
+template<class ForwardIt>
+void uninitialized_default_construct(ForwardIt first, ForwardIt last) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; first != last; ++first) {
+		new(static_cast<void*>(&*first)) value_type;
+	}
+}
+
+/** Constructs n objects in the uninitialized storage starting at first by default-initialization. */
+template<class ForwardIt, class Size>
+ForwardIt uninitialized_default_construct_n(ForwardIt first, Size n) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; n; ++first, --n) {
+		new(static_cast<void*>(&*first)) value_type;
+	}
+
+	return first;
+}
+
+/** Constructs objects in the uninitialized storage designated by the range [first, last] by value-initialization. */
+template<class ForwardIt>
+void uninitialized_value_construct(ForwardIt first, ForwardIt last) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; first != last; ++first) {
+		new(static_cast<void*>(&*first)) value_type();
+	}
+}
+
+/** Constructs n objects in the uninitialized storage starting at first by value-initialization. */
+template<class ForwardIt, class Size>
+ForwardIt uninitialized_value_construct_n(ForwardIt first, Size n) {
+	typedef typename iterator_traits<ForwardIt>::value_type value_type;
+
+	for (; n; ++first, --n) {
+		new(static_cast<void*>(&*first)) value_type();
+	}
+
+	return first;
+}
+
+/** Calls the destructor of the object pointed to by p, as if by p->~T(). */
+template<typename T>
+void destroy_at(T* p) {
+	p->~T();
+}
+
+/** Destroys the objects in the range [first, last]. */
+template<class ForwardIt>
+void destroy(ForwardIt first, ForwardIt last) {
+	for (; first != last; ++first) { destroy_at(&*first); }
+}
+
+/** Destroys the n objects in the range starting at first. */
+template<class ForwardIt, class Size>
+ForwardIt destroy_n(ForwardIt first, Size n) {
+	for (; n; ++first, --n) { destroy_at(&*first); }
+
+	return first;
+}
+
+} /* namespace sstl */
+
+#endif /* STATIC_STL_MEMORY_H_ */

--- a/inc/sstl
+++ b/inc/sstl
@@ -11,6 +11,7 @@
 #include "algorithm.h"
 #include "array.h"
 #include "iterator.h"
+#include "memory.h"
 #include "type_traits.h"
 #include "utility.h"
 #include "vector.h"

--- a/inc/vector.h
+++ b/inc/vector.h
@@ -2,6 +2,7 @@
 #define STATIC_STL_VECTOR_H_
 
 #include "array.h"
+#include "memory.h"
 #include "type_traits.h"
 
 namespace sstl {
@@ -13,7 +14,7 @@ class vector;
 /** Common zero-size base class for all vectors. */
 template<typename T>
 class vector<T> {
-	typedef vector<T, 1> child;
+	typedef vector<T, 8> child;
 
   public:
 	typedef T                                value_type;
@@ -30,77 +31,54 @@ class vector<T> {
 
 	/** Copy assignment operator. */
 	vector& operator=(const vector& rhs) {
-		size_ = rhs.size();
-		fill_n(copy_n(rhs.begin(), size_, begin()),
-		       static_cast<child*>(this)->data_.size() - size_,
-		       T());
+		assign(rhs.begin(), rhs.end());
 		return *this;
 	}
 	/** Copy assignment operator for compatible vector. */
 	template<typename T2>
 	vector& operator=(const vector<T2>& rhs) {
-		size_ = min(rhs.size(), static_cast<child*>(this)->data_.size());
-		fill_n(copy_n(rhs.begin(), size_, begin()),
-		       static_cast<child*>(this)->data_.size() - size_,
-		       T());
+		assign(rhs.begin(), rhs.end());
 		return *this;
 	}
 
 	/** Random access operator. */
-	reference operator[](size_type pos) {
-		return static_cast<child*>(this)->data_[pos];
-	}
-	const_reference operator[](size_type pos) const {
-		return static_cast<const child*>(this)->data_[pos];
-	}
+	reference operator[](size_type pos) { return begin()[pos]; }
+	const_reference operator[](size_type pos) const { return begin()[pos]; }
 
 	/** Replaces the contents with count copies of value val. */
 	void assign(size_type count, const_reference val) {
-		size_ = min(count, static_cast<child*>(this)->data_.size());
-		fill_n(fill_n(begin(), size_, val),
-		       static_cast<child*>(this)->data_.size() - size_,
-		       T());
+		resize(count);
+		fill_n(begin(), size_, val);
 	}
 	/** Replaces the contents with copies of those in the range [first, last]. */
-	// template<class InputIt>
-	// void assign(InputIt first, InputIt last) {
-	//  size_ = min(distance(first, last),
-	//              static_cast<child*>(this)->data_.size());
-	//  fill_n(copy_n(first, size_, begin()),
-	//         static_cast<child*>(this)->data_.size() - size_,
-	//         T());
-	// }
+	template<class InputIt>
+	void assign(InputIt first, InputIt last) {
+		typedef typename is_integral<InputIt>::type integral;
+		assign_range_dispatch(first, last, integral());
+	}
 
 	/** Returns a reference to the element at specified location pos, with bounds checking. */
-	reference at(size_type pos) {
-		return static_cast<child*>(this)->data_[pos % size_];
-	}
-	const_reference at(size_type pos) const {
-		return static_cast<const child*>(this)->data_[pos % size_];
-	}
+	reference at(size_type pos) { return begin()[pos % max_size()]; }
+	const_reference at(size_type pos) const { return begin()[pos % max_size()]; }
 
 	/** Returns a reference to the first element in the container. */
-	reference front() { return static_cast<child*>(this)->data_.front(); }
-	const_reference front() const {
-		return static_cast<const child*>(this)->data_.front();
-	}
+	reference front() { return *begin(); }
+	const_reference front() const { return *begin(); }
 
 	/** Returns reference to the last element in the container. */
-	reference back() { return static_cast<child*>(this)->data_[size_ - 1]; }
-	const_reference back() const {
-		return static_cast<const child*>(this)->data_[size_ - 1];
-	}
+	reference back() { return end()[-1]; }
+	const_reference back() const { return end()[-1]; }
 
 	/** Returns pointer to the underlying array serving as element storage. */
-	pointer data() { return static_cast<child*>(this)->data_.data(); }
+	pointer data() { return pointer(static_cast<child*>(this)->data_.data()); }
 	const_pointer data() const {
-		return static_cast<const child*>(this)->data_.data();
+		return const_pointer(static_cast<const child*>(this)->data_.data());
 	}
 
 	/** Returns an iterator to the first element of the container. */
-	iterator begin() { return static_cast<child*>(this)->data_.begin(); }
+	iterator begin() { return iterator(static_cast<child*>(this)->data_.begin()); }
 	const_iterator begin() const {
-		return static_cast<const child*>(this)->data_.begin();
+		return const_iterator(static_cast<const child*>(this)->data_.begin());
 	}
 	const_iterator cbegin() const { return begin(); }
 
@@ -128,22 +106,18 @@ class vector<T> {
 		return static_cast<const child*>(this)->data_.size();
 	}
 	/** Returns the number of elements that the container has currently allocated space for. */
-	size_type capacity() const {
-		return static_cast<const child*>(this)->data_.size();
-	}
+	size_type capacity() const { return max_size(); }
 
 	/** Removes all elements from the container. */
-	void clear() { fill(begin(), end(), T()); size_ = 0; }
+	void clear() { resize(0); }
 
 	/** Inserts val before pos. */
 	iterator insert(const_iterator pos, const_reference val) {
 		if (size_ < max_size()) {
+			resize(size_ + 1);
 			const difference_type d = distance(cbegin(), pos);
-			rotate(rbegin() - 1,
-			       rbegin(),
-			       reverse_iterator(begin() + d)).base();
+			rotate(rbegin(), rbegin() + 1, reverse_iterator(begin() + d));
 			*iterator(pos) = val;
-			++size_;
 		}
 
 		return iterator(pos);
@@ -151,70 +125,64 @@ class vector<T> {
 	iterator insert(const_iterator pos, size_type count, const_reference val) {
 		if (size_ < max_size()) {
 			count = min(count, max_size() - size_);
+			resize(size_ + count);
 			const difference_type d = distance(cbegin(), pos);
-			rotate(rbegin() - count,
-			       rbegin(),
-			       reverse_iterator(begin() + d)).base();
+			rotate(rbegin(), rbegin() + count, reverse_iterator(begin() + d));
 			fill_n(iterator(pos), count, val);
-			size_ += count;
 		}
 
 		return iterator(pos);
 	}
-	// template<class InputIt>
-	// iterator insert(iterator pos, InputIt first, InputIt last) {}
+	template<class InputIt>
+	iterator insert(const_iterator pos, InputIt first, InputIt last) {
+		typedef typename is_integral<InputIt>::type integral;
+		return insert_range_dispatch(pos, first, last, integral());
+	}
 
 	/** Removes specified elements from the container. */
 	iterator erase(const_iterator pos) {
 		iterator it = iterator(pos);
-		*it = T();
 		rotate(it, it + 1, end());
-		--size_;
+		resize(size_ - 1);
 		return it;
 	}
 	iterator erase(const_iterator first, const_iterator last) {
 		iterator start = iterator(first);
 		iterator finish = iterator(last);
-
-		fill(start, finish, T());
 		rotate(start, finish, end());
-		size_ -= distance(start, finish);
-
+		resize(size_ - distance(start, finish));
 		return start;
 	}
 
 	/** Appends the given element value to the end of the container. */
 	void push_back(const T& value) {
 		if (size_ < max_size()) {
-			*end() = value;
+			uninitialized_fill_n(end(), 1, value);
 			++size_;
 		}
 	}
 
 	/** Removes the last element of the container. */
-	void pop_back() {
-		back() = T();
-		--size_;
-	}
+	void pop_back() { resize(size_ - 1); }
 
 	/** Resizes the container to contain count elements. */
 	void resize(size_type count) {
-		if (size_ >= count) {
-			fill(begin() + count, end(), T());
+		if (count <= size_) {
+			destroy(begin() + count, end());
 			size_ = count;
 		} else {
 			count = min(count, max_size());
-			fill(end(), begin() + count, T());
+			uninitialized_value_construct(end(), begin() + count);
 			size_ = count;
 		}
 	}
 	void resize(size_type count, const value_type& value) {
-		if (size_ >= count) {
-			fill(begin() + count, end(), T());
+		if (count <= size_) {
+			destroy(begin() + count, end());
 			size_ = count;
 		} else {
 			count = min(count, max_size());
-			fill(end(), begin() + count, value);
+			uninitialized_fill(end(), begin() + count, value);
 			size_ = count;
 		}
 	}
@@ -224,6 +192,37 @@ class vector<T> {
 	~vector() {}
 
 	size_type size_;
+
+  private:
+	template<class Int>
+	void assign_range_dispatch(Int count, Int val, true_type) {
+		assign(size_type(count), const_reference(val));
+	}
+	template<class InputIt>
+	void assign_range_dispatch(InputIt first, InputIt last, false_type) {
+		resize(distance(first, last));
+		copy_n(first, size_, begin());
+	}
+
+	template<class InputIt>
+	iterator insert_range_dispatch(const_iterator pos, InputIt first, InputIt last,
+	                               true_type) {
+		return insert(pos, size_type(first), value_type(last));
+	}
+	template<class InputIt>
+	iterator insert_range_dispatch(const_iterator pos, InputIt first, InputIt last,
+	                               false_type) {
+		if (size_ < max_size()) {
+			difference_type count = min(distance(first, last),
+			                            difference_type(max_size() - size_));
+			resize(size_ + count);
+			const difference_type d = distance(cbegin(), pos);
+			rotate(rbegin(), rbegin() + count, reverse_iterator(begin() + d));
+			copy_n(first, count, iterator(pos));
+		}
+
+		return iterator(pos);
+	}
 };
 
 /** Child class with size-specific storage for the underlying array. */
@@ -248,17 +247,21 @@ class vector : public vector<T> {
 	/** Default constructor. */
 	vector() : base(0) {}
 	/** Copy constructor. */
-	vector(const vector& other) : base(other.size()), data_(other.data_) {}
+	vector(const vector& other) : base(other.size()) {
+		uninitialized_copy_n(other.begin(), base::size_, base::begin());
+	}
 	/** Copy adapter constructor. */
 	template<typename T2>
 	vector(const vector<T2>& other) : base(min(other.size(), N)) {
-		copy_n(other.begin(), base::size_, base::begin());
+		uninitialized_copy_n(other.begin(), base::size_, base::begin());
 	}
 	/** Constructs the vector with count default initialized elements. */
-	explicit vector(size_type count) : base(min(count, N)) {}
+	explicit vector(size_type count) : base(min(count, N)) {
+		uninitialized_value_construct_n(base::begin(), base::size_);
+	}
 	/** Constructs the vector with count elements having value val. */
 	vector(size_type count, const_reference val) : base(min(count, N)) {
-		fill_n(base::begin(), base::size_, val);
+		uninitialized_fill_n(base::begin(), base::size_, val);
 	}
 	/** Constructs the vector with values from range [first, last]. */
 	template<class InputIt>
@@ -267,33 +270,36 @@ class vector : public vector<T> {
 		construct_range_dispatch(first, last, integral());
 	}
 
+	~vector() { destroy(base::begin(), base::end()); }
+
 	/** Copy assignment operator. */
 	vector& operator=(const vector& rhs) {
-		base::size_ = rhs.size();
-		fill_n(copy_n(rhs.begin(), base::size_, base::begin()), N - base::size_, T());
+		base::assign(rhs.begin(), rhs.end());
 		return *this;
 	}
 	/** Copy assignment operator for compatible vector. */
 	template<typename T2>
 	vector& operator=(const vector<T2>& rhs) {
-		base::size_ = min(rhs.size(), N);
-		fill_n(copy_n(rhs.begin(), base::size_, base::begin()), N - base::size_, T());
+		base::assign(rhs.begin(), rhs.end());
 		return *this;
 	}
 
   private:
-	template<typename Int>
+	template<class Int>
 	void construct_range_dispatch(Int count, Int val, true_type) {
 		base::size_ = min(size_type(count), N);
-		fill_n(base::begin(), base::size_, value_type(val));
+		uninitialized_fill_n(base::begin(), base::size_, value_type(val));
 	}
-	template<typename InputIt>
+	template<class InputIt>
 	void construct_range_dispatch(InputIt first, InputIt last, false_type) {
 		base::size_ = min(size_type(distance(first, last)), N);
-		copy_n(first, base::size_, base::begin());
+		uninitialized_copy_n(first, base::size_, base::begin());
 	}
 
-	array<T, N> data_;
+	typedef typename
+	aligned_storage<sizeof(T), alignment_of<T>::value>::type element;
+
+	array<element, N> data_;
 };
 
 template<typename T>

--- a/test/memory.cpp
+++ b/test/memory.cpp
@@ -1,0 +1,162 @@
+#include "catch/catch.hpp"
+
+#include "algorithm.h"
+#include "memory.h"
+#include "type_traits.h"
+
+struct Foo {
+	Foo() : value(48) {}
+	explicit Foo(int v) : value(v) {}
+	~Foo() { value = 96; }
+
+	bool operator==(const Foo& rhs) { return value == rhs.value; }
+
+	volatile int value;
+};
+
+TEST_CASE("Copy elements into uninitialized memory", "[uninitialized]") {
+	const size_t count = 4;
+
+	sstl::aligned_storage<sizeof(Foo), sstl::alignment_of<Foo>::value>::type
+	memory[count];
+
+	Foo* dest = reinterpret_cast<Foo*>(memory);
+
+	SECTION("Copy range of elements") {
+		Foo source[count];
+		source[0].value = 2;
+		source[1].value = 4;
+		source[2].value = 8;
+		source[3].value = 16;
+
+		sstl::uninitialized_copy(source, source + count, dest);
+
+		REQUIRE(sstl::equal(dest, dest + count, source));
+	}
+
+	SECTION("Copy n elements") {
+		Foo source[count];
+		source[0].value = 2;
+		source[1].value = 4;
+		source[2].value = 8;
+		source[3].value = 16;
+
+		sstl::uninitialized_copy_n(source, count, dest);
+
+		REQUIRE(sstl::equal(dest, dest + count, source));
+	}
+}
+
+TEST_CASE("Fill uninitialized memory with value", "[uninitialized]") {
+	const size_t count = 4;
+
+	sstl::aligned_storage<sizeof(Foo), sstl::alignment_of<Foo>::value>::type
+	memory[count];
+
+	Foo* dest = reinterpret_cast<Foo*>(memory);
+
+	SECTION("Fill range of elements") {
+		Foo source[count];
+
+		sstl::fill(source, source + count, Foo(16));
+
+		sstl::uninitialized_fill(dest, dest + count, Foo(16));
+
+		REQUIRE(sstl::equal(dest, dest + count, source));
+	}
+
+	SECTION("Fill n elements") {
+		Foo source[count];
+
+		sstl::fill(source, source + count, Foo(16));
+
+		sstl::uninitialized_fill_n(dest, count, Foo(16));
+
+		REQUIRE(sstl::equal(dest, dest + count, source));
+	}
+}
+
+TEST_CASE("Default construct in uninitialized memory", "[uninitialized]") {
+	const size_t count = 4;
+
+	sstl::aligned_storage<sizeof(Foo), sstl::alignment_of<Foo>::value>::type
+	memory[count];
+
+	Foo* dest = reinterpret_cast<Foo*>(memory);
+
+	SECTION("Construct range of elements") {
+		Foo expect[count];
+
+		sstl::uninitialized_default_construct(dest, dest + count);
+
+		REQUIRE(sstl::equal(dest, dest + count, expect));
+	}
+
+	SECTION("Construct n elements") {
+		Foo expect[count];
+
+		sstl::uninitialized_default_construct_n(dest, count);
+
+		REQUIRE(sstl::equal(dest, dest + count, expect));
+	}
+}
+
+TEST_CASE("Value construct in uninitialized memory", "[uninitialized]") {
+	const size_t count = 4;
+
+	sstl::aligned_storage<sizeof(int), sstl::alignment_of<int>::value>::type
+	memory[count];
+
+	int* dest = reinterpret_cast<int*>(memory);
+
+	SECTION("Construct range of elements") {
+		int expect[count] = {0};
+
+		sstl::uninitialized_value_construct(dest, dest + count);
+
+		REQUIRE(sstl::equal(dest, dest + count, expect));
+	}
+
+	SECTION("Construct n elements") {
+		int expect[count] = {0};
+
+		sstl::uninitialized_value_construct_n(dest, count);
+
+		REQUIRE(sstl::equal(dest, dest + count, expect));
+	}
+}
+
+TEST_CASE("Destroy elements", "[uninitialized]") {
+	const size_t count = 4;
+
+	sstl::aligned_storage<sizeof(Foo), sstl::alignment_of<Foo>::value>::type
+	memory[count];
+
+	Foo* dest = reinterpret_cast<Foo*>(memory);
+
+	sstl::uninitialized_default_construct_n(dest, count);
+
+	SECTION("Destroy item at pointer") {
+		sstl::destroy_at(dest);
+
+		REQUIRE(dest[0].value == 96);
+	}
+
+	SECTION("Destroy range") {
+		Foo expect[count];
+		sstl::fill_n(expect, count, Foo(96));
+
+		sstl::destroy(dest, dest + count);
+
+		REQUIRE(sstl::equal(dest, dest + count, expect));
+	}
+
+	SECTION("Destroy n elements") {
+		Foo expect[count];
+		sstl::fill_n(expect, count, Foo(96));
+
+		sstl::destroy_n(dest, count);
+
+		REQUIRE(sstl::equal(dest, dest + count, expect));
+	}
+}

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -164,6 +164,22 @@ TEST_CASE("Index into a vector", "[access]") {
 			REQUIRE(a.data()[count] == overflow);
 		}
 	}
+
+	SECTION("Using front and back") {
+		a.front() = 12;
+		a.back() = 24;
+
+		REQUIRE(a[0] == 12);
+		REQUIRE(a[a.size() - 1] == 24);
+	}
+
+	SECTION("Using underlying pointer") {
+		a.front() = 12;
+		a.back() = 24;
+
+		REQUIRE(a.data()[0] == 12);
+		REQUIRE(a.data()[a.size() - 1] == 24);
+	}
 }
 
 TEST_CASE("Iterate over a vector", "[iterator]") {
@@ -245,6 +261,27 @@ TEST_CASE("Insert values into a vector", "[modifiers]") {
 
 		REQUIRE(a[2] == 'd');
 	}
+
+	SECTION("Many at a time") {
+		a.insert(a.begin() + 1, 2, 'e');
+
+		REQUIRE(a[0] == 'a');
+		REQUIRE(a[1] == 'e');
+		REQUIRE(a[2] == 'e');
+		REQUIRE(a[3] == 'a');
+	}
+
+	SECTION("With a range") {
+		char b[4] = {'b', 'c', 'd', 'e'};
+
+		a.insert(a.begin() + 1, b, b + 4);
+
+		REQUIRE(a[0] == 'a');
+		REQUIRE(a[1] == 'b');
+		REQUIRE(a[2] == 'c');
+		REQUIRE(a[3] == 'd');
+		REQUIRE(a[4] == 'e');
+	}
 }
 
 TEST_CASE("Remove values from a vector", "[modifiers]") {
@@ -284,6 +321,15 @@ TEST_CASE("Remove values from a vector", "[modifiers]") {
 
 		REQUIRE(a.size() == 8);
 		REQUIRE(a.back() == 'a');
+	}
+
+	SECTION("Erase a range of elements") {
+		a.insert(a.begin(), 'b');
+
+		a.erase(a.begin() + 1, a.end());
+
+		REQUIRE(a.size() == 1);
+		REQUIRE(a.back() == 'b');
 	}
 }
 


### PR DESCRIPTION
Vector class now uses raw memory and placement new to manage its backing storage. This approach is slightly more efficient than calling all the unnecessary default constructors. Also plays nicer with objects whose existence claims resources.