### PR TITLE
Implement all comparison operators

### DIFF
--- a/inc/array.h
+++ b/inc/array.h
@@ -165,9 +165,29 @@ inline bool operator==(const array<T>& lhs, const array<T>& rhs) {
 }
 
 template<typename T>
+inline bool operator!=(const array<T>& lhs, const array<T>& rhs) {
+	return !(lhs == rhs);
+}
+
+template<typename T>
 inline bool operator<(const array<T>& lhs, const array<T>& rhs) {
 	return lexicographical_compare(lhs.cbegin(), lhs.cend(),
 	                               rhs.cbegin(), rhs.cend());
+}
+
+template<typename T>
+inline bool operator>(const array<T>& lhs, const array<T>& rhs) {
+	return rhs < lhs;
+}
+
+template<typename T>
+inline bool operator<=(const array<T>& lhs, const array<T>& rhs) {
+	return !(rhs < lhs);
+}
+
+template<typename T>
+inline bool operator>=(const array<T>& lhs, const array<T>& rhs) {
+	return !(lhs < rhs);
 }
 
 } /* namespace sstl */

--- a/inc/iterator.h
+++ b/inc/iterator.h
@@ -103,9 +103,33 @@ bool operator==(const reverse_iterator<Iterator1>& lhs,
 }
 
 template<class Iterator1, class Iterator2>
+bool operator!=(const reverse_iterator<Iterator1>& lhs,
+                const reverse_iterator<Iterator2>& rhs) {
+	return !(lhs == rhs);
+}
+
+template<class Iterator1, class Iterator2>
 bool operator<(const reverse_iterator<Iterator1>& lhs,
                const reverse_iterator<Iterator2>& rhs) {
 	return lhs.base() < rhs.base();
+}
+
+template<class Iterator1, class Iterator2>
+bool operator>(const reverse_iterator<Iterator1>& lhs,
+               const reverse_iterator<Iterator2>& rhs) {
+	return rhs < lhs;
+}
+
+template<class Iterator1, class Iterator2>
+bool operator<=(const reverse_iterator<Iterator1>& lhs,
+                const reverse_iterator<Iterator2>& rhs) {
+	return !(rhs < lhs);
+}
+
+template<class Iterator1, class Iterator2>
+bool operator>=(const reverse_iterator<Iterator1>& lhs,
+                const reverse_iterator<Iterator2>& rhs) {
+	return !(lhs < rhs);
 }
 
 /** Returns the number of hops from first to last. */

--- a/inc/utility.h
+++ b/inc/utility.h
@@ -3,6 +3,8 @@
 
 namespace sstl {
 
+namespace rel_ops {
+
 /** Implements operator!= in terms of operator==. */
 template<class T>
 bool operator!=(const T& lhs, const T& rhs) { return !(lhs == rhs); }
@@ -18,6 +20,8 @@ bool operator<=(const T& lhs, const T& rhs) { return !(rhs < lhs); }
 /** Implements operator>= in terms of operator<. */
 template<class T>
 bool operator>=(const T& lhs, const T& rhs) { return !(lhs < rhs); }
+
+} /* namespace rel_ops */
 
 } /* namespace sstl */
 

--- a/inc/vector.h
+++ b/inc/vector.h
@@ -309,9 +309,29 @@ inline bool operator==(const vector<T>& lhs, const vector<T>& rhs) {
 }
 
 template<typename T>
+inline bool operator!=(const vector<T>& lhs, const vector<T>& rhs) {
+	return !(lhs == rhs);
+}
+
+template<typename T>
 inline bool operator<(const vector<T>& lhs, const vector<T>& rhs) {
 	return lexicographical_compare(lhs.cbegin(), lhs.cend(),
 	                               rhs.cbegin(), rhs.cend());
+}
+
+template<typename T>
+inline bool operator>(const vector<T>& lhs, const vector<T>& rhs) {
+	return rhs < lhs;
+}
+
+template<typename T>
+inline bool operator<=(const vector<T>& lhs, const vector<T>& rhs) {
+	return !(rhs < lhs);
+}
+
+template<typename T>
+inline bool operator>=(const vector<T>& lhs, const vector<T>& rhs) {
+	return !(lhs < rhs);
 }
 
 } /* namespace sstl */

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -202,20 +202,14 @@ TEST_CASE("Test arrays for equality", "[comparison]") {
 
 	SECTION("With a smaller size array") {
 		sstl::array<char, 2> b(16);
-		// TODO: This should be able to work without taking a parent reference.
-		sstl::array<char>& aref = a;
-		sstl::array<char>& bref = b;
 
-		REQUIRE(aref != bref);
+		REQUIRE(a != b);
 	}
 
 	SECTION("With a larger size array") {
 		sstl::array<char, 5> b(16);
-		// TODO: This should be able to work without taking a parent reference.
-		sstl::array<char>& aref = a;
-		sstl::array<char>& bref = b;
 
-		REQUIRE(aref != bref);
+		REQUIRE(a != b);
 	}
 }
 

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -394,20 +394,14 @@ TEST_CASE("Test vectors for equality", "[comparison]") {
 
 	SECTION("With a smaller size vector") {
 		sstl::vector<char, 2> b(2, 16);
-		// TODO: This should be able to work without taking a parent reference.
-		sstl::vector<char>& aref = a;
-		sstl::vector<char>& bref = b;
 
-		REQUIRE(aref != bref);
+		REQUIRE(a != b);
 	}
 
 	SECTION("With a larger size vector") {
 		sstl::vector<char, 5> b(5, 16);
-		// TODO: This should be able to work without taking a parent reference.
-		sstl::vector<char>& aref = a;
-		sstl::vector<char>& bref = b;
 
-		REQUIRE(aref != bref);
+		REQUIRE(a != b);
 	}
 }
 


### PR DESCRIPTION
Instead of relying on the generic template versions, add missing comparison operators to classes.

This lets us use direct comparisons via the base classes and not get compiler errors.